### PR TITLE
BREAKING CHANGE: fix 32bit linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadow"
-version = "0.0.1"
+version = "1.0.0"
 authors = ["Ian D. Scott <ian@iandouglasscott.com>"]
 description = "Bindings for libc /etc/shadow password functions"
 repository = "https://github.com/ids1024/shadow-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ extern crate libc;
 use std::ffi::CString;
 use std::ffi::CStr;
 
+type Long = libc::c_long;
 
 /// Represents an entry in `/etc/shadow`
 #[derive(Debug)]
@@ -47,17 +48,17 @@ pub struct Shadow {
     /// encrypted password
     pub password: String,
     /// last password change
-    pub last_change: i64,
+    pub last_change: Long,
     /// days until change allowed
-    pub min: i64,
+    pub min: Long,
     /// days before change required
-    pub max: i64,
+    pub max: Long,
     /// days warning for expiration
-    pub warn: i64,
+    pub warn: Long,
     /// days before account inactive
-    pub inactive: i64,
+    pub inactive: Long,
     /// date when account expires
-    pub expire: i64,
+    pub expire: Long,
 }
 
 impl Shadow {


### PR DESCRIPTION
Adds `Long` type which alias' the `libc::c_long` type.

Updates the `Shadow` struct to use `Long` rather than `i64` -- this is a breaking change, which oddly enough fixes the only platforms it would have broken...

Still bumps the major version where code that utilizes this will now have to conditionally coerce types if building for both `arm` && `aarch64`